### PR TITLE
fix grep -P error

### DIFF
--- a/autoload/ctrlp/hg_status.vim
+++ b/autoload/ctrlp/hg_status.vim
@@ -22,7 +22,7 @@ else
 endif
 
 function! ctrlp#hg_status#init()
-  return map(split(s:system("hg status | grep -P '^\\?|A|M '"), "\n"), 'v:val')
+  return map(split(s:system("hg status | grep -e '^[?|A|M] '"), "\n"), 'v:val')
 endfunc
 
 function! ctrlp#hg_status#accept(mode, str)


### PR DESCRIPTION
* 'grep -P' will prompt an error  as follows, so I change it to 'grep -e'
```
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
```